### PR TITLE
Replace d3 json fetching with nodes https module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var d3 = require('d3');
 var queue = require('queue-async');
+var https = require('https');
 
 module.exports = geocodemany;
 
@@ -31,11 +32,36 @@ function geocodemany(mapid, throttle) {
         function copy(o) { return JSON.parse(JSON.stringify(o)); }
 
         function run(obj, callback) {
+
             var str = transform(obj);
             var output = copy(obj);
-            d3.json('https://api.tiles.mapbox.com/v3/' + mapid + '/geocode/' +
-                encodeURIComponent(str) + '.json')
-                .on('load', function(data) {
+
+            var options = {
+                hostname: 'api.tiles.mapbox.com',
+                path: '/v3/' + mapid + '/geocode/' + encodeURIComponent(str) + '.json',
+                method: 'GET',
+                agent: false
+            }
+
+            var req = https.request(options, function(res) {
+                var data = '';
+
+                res.on('data', function(chunk) {
+                    data += chunk;
+                });
+
+                res.on('error', function () {
+                    error({
+                        error: new Error('Location not found'),
+                        __iserror__: true,
+                        data: output
+                    }, callback);
+                });
+
+                res.on('end', function () {
+
+                    data = JSON.parse(data);
+
                     if (data && data.results && data.results.length &&
                         data.results[0].length) {
 
@@ -64,16 +90,19 @@ function geocodemany(mapid, throttle) {
 
                     }
                 })
-                .on('error', function(err) {
+            })
 
-                    error({
-                        error: err,
-                        __iserror__: true,
-                        data: output
-                    }, callback);
+            req.on('error', function(err) {
+                error({
+                    error: err,
+                    __iserror__: true,
+                    data: output
+                }, callback);
+            });
 
-                })
-                .get();
+            req.shouldKeepAlive = false;
+
+            req.end();
         }
 
         function enqueue(obj) {

--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ function geocodemany(mapid, throttle) {
                 hostname: 'api.tiles.mapbox.com',
                 path: '/v3/' + mapid + '/geocode/' + encodeURIComponent(str) + '.json',
                 method: 'GET',
-                agent: false
+                agent: false,
+                port: 443,
+                withCredentials: false
             }
 
             var req = https.request(options, function(res) {


### PR DESCRIPTION
Hey,

I replaced your use of d3 with nodes https module so that I could run my geocoding scripts from node rather than in the browser. 

This scratched my own itch but I have no idea if you have any use for this code yourself...

In any case, here it is. Feel free to reject outright. 

Thanks for the great module!